### PR TITLE
Run `tailwindcss` in build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "concurrently npm:watch:*",
     "watch:tw": "tailwindcss -i ./assets/css/main.css -o ./assets/css/style.css --watch",
     "watch:hugo": "hugo server",
-    "build": "hugo --minify"
+    "build": "tailwindcss -i ./assets/css/main.css -o ./assets/css/style.css && hugo --minify"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thanks for creating such a useful pairing!

I've added `./assets/css/style.css` to my `.gitignore` since it changes so frequently. When I build my site in CI, running `npm run build` fails because `./assets/css/style.css` doesn't exist. I think it assumes you've run `npm run start` at least once. This change ensures `style.css` exists before building with Hugo.